### PR TITLE
카카오 로그인 API 사용시 스펙이 다름으로 인해 발생하는 오류 수정

### DIFF
--- a/backend/src/main/java/com/cherish/backend/util/SocialLoginValidationUtil.java
+++ b/backend/src/main/java/com/cherish/backend/util/SocialLoginValidationUtil.java
@@ -2,6 +2,8 @@ package com.cherish.backend.util;
 
 import com.cherish.backend.domain.Platform;
 import com.cherish.backend.exception.WrongOauthIdException;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
@@ -40,6 +42,7 @@ public class SocialLoginValidationUtil {
 
         ResponseEntity<KakaoValidationResponseDTO> response = restTemplate.exchange(
                 url, HttpMethod.GET, new HttpEntity(headers), KakaoValidationResponseDTO.class);
+
         return response.getBody().getId();
     }
 
@@ -47,15 +50,14 @@ public class SocialLoginValidationUtil {
 
     }
 
+}
 
-    class KakaoValidationResponseDTO {
-        private String id;
-        private String expires_in;
-        private String app_id;
-
-        public String getId() {
-            return id;
-        }
-    }
-
+@Getter
+@NoArgsConstructor
+class KakaoValidationResponseDTO {
+    private String id;
+    private String expires_in;
+    private String app_id;
+    private String appId;
+    private String expiresInMillis;
 }


### PR DESCRIPTION
## 개요
카카오 로그인 API 사용시 스펙이 다름으로 인해 발생하는 오류 수정


### PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 반영 브랜치
ex)feat/kakaologinvalidation -> dev

### 변경 사항
카카오 API ResponseDTO를 수정하였습니다.

### PR CHECK
- [ x  ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ x ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
